### PR TITLE
HUB-505: fix instance host parsing logic

### DIFF
--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module SalesforceBulk
 
   class Connection
@@ -36,7 +38,7 @@ module SalesforceBulk
       xml += "    </n1:login>"
       xml += "  </env:Body>"
       xml += "</env:Envelope>"
-      
+
       headers = Hash['Content-Type' => 'text/xml; charset=utf-8', 'SOAPAction' => 'login']
 
       response = post_xml(@@LOGIN_HOST, @@LOGIN_PATH, xml, headers)
@@ -45,9 +47,13 @@ module SalesforceBulk
 
       @session_id = response_parsed['Body'][0]['loginResponse'][0]['result'][0]['sessionId'][0]
       @server_url = response_parsed['Body'][0]['loginResponse'][0]['result'][0]['serverUrl'][0]
-      @instance = parse_instance()
 
-      @@INSTANCE_HOST = "#{@instance}.salesforce.com"
+      @@INSTANCE_HOST = instance_host()
+    end
+
+    def instance_host()
+      url = URI.parse(@server_url)
+      url.host
     end
 
     def post_xml(host, path, xml, headers)
@@ -100,7 +106,7 @@ module SalesforceBulk
 
       if response.downcase.include?("faultstring") || response.downcase.include?("exceptionmessage")
         begin
-          
+
           if response.downcase.include?("faultstring")
             error_message = response_parsed["Body"][0]["Fault"][0]["faultstring"][0]
           elsif response.downcase.include?("exceptionmessage")


### PR DESCRIPTION
- instead of using regex to read out the host part of returning server
  url, user URI.parse instead